### PR TITLE
fix(ext header links)

### DIFF
--- a/ramda-docs/scripts.js
+++ b/ramda-docs/scripts.js
@@ -23,9 +23,27 @@ async function getData() {
   return layout;
 }
 
+function fixHeaderLinks(doc) {
+  const menuLinks = [...doc.querySelectorAll('header.navbar a')]
+    .map(a => {
+      const href = a.getAttribute('href');
+      if (/^(\/|#|\.\.)/i.test(href)) {
+        // make the relative link absolute
+        const externalHref = `http://ramdajs.com/docs/${ href.replace(/^\//, '../') }`;
+        // fix paths like '/docs/../repl' to '/repl'
+        a.setAttribute('href', externalHref.replace(/\/[^\/]+\/\.\./, ''));
+      }
+      // When clicked, open in new tab
+      a.setAttribute('target', '_blank');
+    });
+
+  return menuLinks;
+}
+
 function insertData(fn) {
   return async function (element) {
     element.innerHTML = (typeof fn === 'function') ? await fn() : fn;
     ramdaInit();
+    fixHeaderLinks(document);
   }
 }


### PR DESCRIPTION
The header links all crashed the extension, so this PR iterates over those links to fix them.
The fix basically
- Checks if the link is external
- If so it makes it open in new tab (target='_blank')
- If the links were relative, then it fixes them to point at correct external link